### PR TITLE
optimization: move import marimo as mo to top of notebook

### DIFF
--- a/optimization/01_least_squares.py
+++ b/optimization/01_least_squares.py
@@ -13,6 +13,12 @@ __generated_with = "0.11.0"
 app = marimo.App()
 
 
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(
@@ -111,12 +117,6 @@ def _(mo):
         """
     )
     return
-
-
-@app.cell
-def _():
-    import marimo as mo
-    return (mo,)
 
 
 if __name__ == "__main__":

--- a/optimization/02_linear_program.py
+++ b/optimization/02_linear_program.py
@@ -15,6 +15,12 @@ __generated_with = "0.11.0"
 app = marimo.App()
 
 
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(
@@ -257,12 +263,6 @@ def _(mo, prob, x):
         """
     )
     return
-
-
-@app.cell
-def _():
-    import marimo as mo
-    return (mo,)
 
 
 if __name__ == "__main__":

--- a/optimization/04_quadratic_program.py
+++ b/optimization/04_quadratic_program.py
@@ -15,6 +15,12 @@ __generated_with = "0.11.0"
 app = marimo.App()
 
 
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(
@@ -253,12 +259,6 @@ def _(np):
         )
         return plt.gca()
     return (plot_contours,)
-
-
-@app.cell
-def _():
-    import marimo as mo
-    return (mo,)
 
 
 if __name__ == "__main__":

--- a/optimization/05_portfolio_optimization.py
+++ b/optimization/05_portfolio_optimization.py
@@ -16,6 +16,12 @@ __generated_with = "0.11.2"
 app = marimo.App()
 
 
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""# Portfolio optimization""")
@@ -245,12 +251,6 @@ def _(gamma, gamma_vals, markers_on, np, plt, prob, ret, risk):
     plt.legend(loc="upper right")
     plt.show()
     return midx, spstats, x
-
-
-@app.cell
-def _():
-    import marimo as mo
-    return (mo,)
 
 
 if __name__ == "__main__":

--- a/optimization/06_convex_optimization.py
+++ b/optimization/06_convex_optimization.py
@@ -13,6 +13,12 @@ __generated_with = "0.11.2"
 app = marimo.App()
 
 
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(
@@ -78,12 +84,6 @@ def _(problem):
 def _(x):
     x.value
     return
-
-
-@app.cell
-def _():
-    import marimo as mo
-    return (mo,)
 
 
 if __name__ == "__main__":

--- a/optimization/07_sdp.py
+++ b/optimization/07_sdp.py
@@ -14,6 +14,12 @@ __generated_with = "0.11.2"
 app = marimo.App()
 
 
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""# Semidefinite program""")
@@ -116,12 +122,6 @@ def _(X, mo, prob, wigglystuff):
 def _():
     import wigglystuff
     return (wigglystuff,)
-
-
-@app.cell
-def _():
-    import marimo as mo
-    return (mo,)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On some browsers (firefox) the marimo playground is very slow to start/autorun. Users then start manually running cells from top to bottom, resulting in "mo not defined" if import marimo as mo is not at the top of the notebook.