### PR TITLE
refactor(fp): v0.1.1 of notebook 05_functors.py

### DIFF
--- a/functional_programming/CHANGELOG.md
+++ b/functional_programming/CHANGELOG.md
@@ -9,3 +9,28 @@
 * `0.1.0` version of notebook `05_functors`
 
 Thank [Akshay](https://github.com/akshayka) and [Haleshot](https://github.com/Haleshot) for reviewing
+
+## 2025-03-16
+
++ Use uppercased letters for `Generic` types, e.g. `A = TypeVar("A")`
++ Refactor the `Functor` class, changing `fmap` and utility methods to `classmethod`
+
+    For example:
+
+    ```python
+    @dataclass
+    class Wrapper(Functor, Generic[A]):
+        value: A
+
+        @classmethod
+        def fmap(cls, f: Callable[[A], B], a: "Wrapper[A]") -> "Wrapper[B]":
+            return Wrapper(f(a.value))
+
+    >>> Wrapper.fmap(lambda x: x + 1, wrapper)
+    Wrapper(value=2)
+    ```
+
++ Move the `check_functor_law` method from `Functor` class to a standard function
+- Rename `ListWrapper` to `List` for simplicity
+- Remove the `Just` class
++ Rewrite proofs


### PR DESCRIPTION
## 📝 Summary

+ Use uppercased letters for `Generic` types, e.g. `A = TypeVar("A")`
+ Refactor the `Functor` class, changing `fmap` and utility methods to `classmethod`

    For example:

    ```python
    @dataclass
    class Wrapper(Functor, Generic[A]):
        value: A

        @classmethod
        def fmap(cls, f: Callable[[A], B], a: "Wrapper[A]") -> "Wrapper[B]":
            return Wrapper(f(a.value))

    >>> Wrapper.fmap(lambda x: x + 1, wrapper)
    Wrapper(value=2)
    ```

+ Move the `check_functor_law` method from `Functor` class to a standard function
- Rename `ListWrapper` to `List` for simplicity
- Remove the `Just` class
+ Rewrite proofs

## 📋 Checklist

- [ ] I have included package dependencies in the notebook file [using `--sandbox`](https://docs.marimo.io/guides/package_reproducibility/)
- [ ] If adding a course, include a `README.md`
- [x] Keep language direct and simple.
