### PR TITLE
Fix `typos` workflow to handle `LaTeX`

### DIFF
--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -13,3 +13,5 @@ jobs:
         uses: styfle/cancel-workflow-action@0.12.1
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@v1.29.4
+        with:
+          config: .typos.toml

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,18 @@
+[default]
+extend-ignore-re = [
+    # LaTeX math expressions
+    "\\\\\\[.*?\\\\\\]",
+    "\\\\\\(.*?\\\\\\)",
+    "\\$\\$.*?\\$\\$",
+    "\\$.*?\\$",
+    # LaTeX commands
+    "\\\\[a-zA-Z]+\\{.*?\\}",
+    "\\\\[a-zA-Z]+",
+    # LaTeX subscripts and superscripts
+    "_\\{.*?\\}",
+    "\\^\\{.*?\\}"
+]
+
+# You can also exclude specific files or directories if needed
+# [files]
+# extend-exclude = ["*.tex", "docs/*.md"] 

--- a/.typos.toml
+++ b/.typos.toml
@@ -13,6 +13,10 @@ extend-ignore-re = [
     "\\^\\{.*?\\}"
 ]
 
+# Words to explicitly accept
+[default.extend-words]
+pn = "pn"
+
 # You can also exclude specific files or directories if needed
 # [files]
 # extend-exclude = ["*.tex", "docs/*.md"] 


### PR DESCRIPTION
## 📝 Summary
Add LaTeX syntax support to typos checker

- Added [`.typos.toml`](https://github.com/crate-ci/typos/blob/master/docs/reference.md) config to handle LaTeX syntax
- Updated the [GitHub workflow](https://github.com/crate-ci/typos) to use this config
- Fixes those annoying [False Positives](https://github.com/crate-ci/typos?tab=readme-ov-file#false-positives) with LaTeX math expressions

Commands to try out locally:

```shell
typos --config .typos.toml <path to `.py` notebook>
```
OR

```shell
typos --config .typos.toml <folder-name>/
```