### PR TITLE
Clarify language around datatype casting and delete empty cell in Polars lazy execution tutorial.

### DIFF
--- a/polars/16_lazy_execution.py
+++ b/polars/16_lazy_execution.py
@@ -271,10 +271,10 @@ def _(log_data):
 def _(mo):
     mo.md(
         r"""
-        Unless specified, Polars defaults to the `pl.String` datatype for all data. This, however, is not the most space or computation efficient form of data storage, so we would like to convert the datatypes of some of the columns in our LazyFrame.
+        Unless specified, Polars defaults to the `pl.String` datatype while reading in the data from the generator. This, however, is not the most space or computation efficient form of data storage, so we would like to convert the datatypes of some of the columns in our LazyFrame.
 
         ///Note
-        The data type conversion can also be done by specifying it in the schema when creating the LazyFrame or DataFrame. We are skipping doing this for demonstration.
+        The data type conversion can also be done by specifying it in the schema when creating the LazyFrame or DataFrame. We are skipping doing this for demonstration. For more details on specifying data types in LazyFrames, please refer to the Polars [documentation](https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html).
         """
     )
     return
@@ -424,12 +424,6 @@ def _(mo):
         For fast iterative development running `.collect` on the entire dataset is not a good idea due to slow runtimes. If your dataset is partitioned, you can use a few of them for testing. Another option is to use `.head` to limit the number of records processed, and `.collect` as few times as possible and toward the end of your query, as shown below.
         """
     )
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r""" """)
     return
 
 

--- a/polars/16_lazy_execution.py
+++ b/polars/16_lazy_execution.py
@@ -271,7 +271,7 @@ def _(log_data):
 def _(mo):
     mo.md(
         r"""
-        Unless specified, Polars defaults to the `pl.String` datatype while reading in the data from the generator. This, however, is not the most space or computation efficient form of data storage, so we would like to convert the datatypes of some of the columns in our LazyFrame.
+        Since our generator yields strings, Polars defaults to the `pl.String` datatype while reading in the data from the generator, unless specified. This, however, is not the most space or computation efficient form of data storage, so we would like to convert the datatypes of some of the columns in our LazyFrame.
 
         ///Note
         The data type conversion can also be done by specifying it in the schema when creating the LazyFrame or DataFrame. We are skipping doing this for demonstration. For more details on specifying data types in LazyFrames, please refer to the Polars [documentation](https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html).


### PR DESCRIPTION
## 📝 Summary

This PR addresses @etrotta's comments in the Polars tutorial for lazy execution (#40). 
1. it changes and add sentences to resolve the ambiguous meaning of the sentence "Unless specified, Polars defaults to the pl.String datatype for all data.",
2. deletes an empty markdown cell. 

## 📋 Checklist

- [x] I have included package dependencies in the notebook file [using `--sandbox`](https://docs.marimo.io/guides/package_reproducibility/)
- [ ] If adding a course, include a `README.md`
- [x] Keep language direct and simple.
