### PR TITLE
fix: add missing dependencies to 03_minimum_fuel_optimal_control.py

### DIFF
--- a/optimization/03_minimum_fuel_optimal_control.py
+++ b/optimization/03_minimum_fuel_optimal_control.py
@@ -1,7 +1,11 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
+#     "cvxpy==1.6.0",
 #     "marimo",
+#     "matplotlib==3.10.0",
+#     "numpy==2.2.2",
+#     "wigglystuff==0.1.9",
 # ]
 # ///
 import marimo


### PR DESCRIPTION
Fixes: https://github.com/cvxpy/cvxpy/issues/3227

## 📝 Summary

<!--
Fixes `ModuleNotFoundError: No module named 'wigglystuff'` when 
running the minimum fuel optimal control example on marimo.app.

The script dependencies block in `03_minimum_fuel_optimal_control.py` 
was missing `cvxpy==1.6.0`, `matplotlib==3.10.0`, `numpy==2.2.2` 
and `wigglystuff==0.1.9` — only `marimo` was listed.

Verified locally using `marimo run` — notebook loads and runs 
correctly after adding the missing dependencies.
-->

## 📋 Checklist

- [x] I have included package dependencies in the notebook file [using `--sandbox`](https://docs.marimo.io/guides/package_reproducibility/)
- [ ] If adding a course, include a `README.md`
- [x] Keep language direct and simple.
